### PR TITLE
MSH: use engine='python' as fallback in pandas to read ogs mesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to **ogs5py** will be documented in this file.
 
 
+## [1.2.2] - 2022-05-25
+
+### Bugfixes
+* `MSH.load`: use `engine='python'` as fallback in pandas to read ogs mesh [#16](https://github.com/GeoStat-Framework/ogs5py/pull/16)
+* removed redundant `from io import open` which were there for py2 compatibility [#16](https://github.com/GeoStat-Framework/ogs5py/pull/16)
+
+
 ## [1.2.1] - 2022-05-15
 
 ### Enhancements
@@ -178,7 +185,8 @@ All notable changes to **ogs5py** will be documented in this file.
 First release of ogs5py.
 
 
-[Unreleased]: https://github.com/GeoStat-Framework/ogs5py/compare/v1.2.1...HEAD
+[Unreleased]: https://github.com/GeoStat-Framework/ogs5py/compare/v1.2.2...HEAD
+[1.2.2]: https://github.com/GeoStat-Framework/ogs5py/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/GeoStat-Framework/ogs5py/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/GeoStat-Framework/ogs5py/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/GeoStat-Framework/ogs5py/compare/v1.1.0...v1.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to **ogs5py** will be documented in this file.
 ## [1.2.2] - 2022-05-25
 
 ### Bugfixes
-* `MSH.load`: use `engine='python'` as fallback in pandas to read ogs mesh [#16](https://github.com/GeoStat-Framework/ogs5py/pull/16)
+* `MSH.load` now uses `engine="python"` as fallback in pandas to successfully read ogs meshes in some corner cases [#16](https://github.com/GeoStat-Framework/ogs5py/pull/16)
 * removed redundant `from io import open` which were there for py2 compatibility [#16](https://github.com/GeoStat-Framework/ogs5py/pull/16)
 
 

--- a/ogs5py/fileclasses/base.py
+++ b/ogs5py/fileclasses/base.py
@@ -343,9 +343,6 @@ class LineFile(File):
         verbose : bool, optional
             Print information of the reading process. Default: False
         """
-        # in python3 open was replaced with io.open
-        # so we can use encoding keyword in python2
-        from io import open
 
         self.reset()
         try:
@@ -941,9 +938,6 @@ class BlockFile(File):
         verbose : bool, optional
             Print information of the reading process. Default: False
         """
-        # in python3 open was replaced with io.open
-        # so we can use encoding key word in python2
-        from io import open
 
         self.reset()
 

--- a/ogs5py/fileclasses/gem/core.py
+++ b/ogs5py/fileclasses/gem/core.py
@@ -303,9 +303,6 @@ class GEMinit:
         -----
         This also reads the given files in the lst-file. (dch, ipm, dbr)
         """
-        # in python3 open was replaced with io.open
-        # so we can use encoding key word in python2
-        from io import open
 
         root = os.path.dirname(path)
 

--- a/ogs5py/fileclasses/gli/tools.py
+++ b/ogs5py/fileclasses/gli/tools.py
@@ -70,8 +70,6 @@ def load_ogs5gli(filepath, verbose=True, encoding=None):
                 - ``LAYER`` (int or None)
 
     """
-    # in python3 open was replaced with io.open
-    from io import open
 
     out = dcp(EMPTY_GLI)
 

--- a/ogs5py/fileclasses/ic/core.py
+++ b/ogs5py/fileclasses/ic/core.py
@@ -309,8 +309,6 @@ class RFR(File):
 
     def read_file(self, path, encoding=None, verbose=False):
         """Write the actual RFR input file to the given folder."""
-        # in python3 open was replaced with io.open
-        from io import open
 
         headers = []
         variables = []

--- a/ogs5py/fileclasses/msh/msh_io.py
+++ b/ogs5py/fileclasses/msh/msh_io.py
@@ -74,8 +74,6 @@ def load_ogs5msh(
     The $AREA keyword within the Nodes definition is NOT supported
     and will violate the read data if present.
     """
-    # in python3 open was replaced with io.open
-    from io import open
 
     import pandas as pd
 
@@ -304,8 +302,6 @@ def load_ogs5msh_old(filepath, verbose=True, max_node_no=8, encoding=None):
             element_id : dict
                 contains element ids for each element sorted by element types
     """
-    # in python3 open was replaced with io.open
-    from io import open
 
     import pandas as pd
 

--- a/ogs5py/fileclasses/msh/msh_io.py
+++ b/ogs5py/fileclasses/msh/msh_io.py
@@ -186,13 +186,16 @@ def load_ogs5msh(
                 filepos = msh.tell()
                 # read the elements with pandas
                 # names=range(max_node_no) to assure rectangular shape by cols
-                tmp = pd.read_csv(
-                    msh,
-                    engine="c",
+                pd_kwargs = dict(
                     delim_whitespace=True,
                     nrows=no_elements,
                     names=range(max_node_no + 4),  # +4 for the "-1" entry
-                ).values
+                )
+                try:
+                    tmp = pd.read_csv(msh, engine="c", **pd_kwargs).values
+                except pd.errors.ParserError:
+                    msh.seek(filepos)
+                    tmp = pd.read_csv(msh, engine="python", **pd_kwargs).values
                 # check if all given element-typs are OGS known
                 pos_ele = 2  # can be shift to right, if "-1" occures
                 check_elem = np.in1d(tmp[:, pos_ele], ELEM_NAMES)

--- a/ogs5py/fileclasses/msh/msh_io.py
+++ b/ogs5py/fileclasses/msh/msh_io.py
@@ -335,13 +335,17 @@ def load_ogs5msh_old(filepath, verbose=True, max_node_no=8, encoding=None):
                 print(no_elements)
             # read the elements with pandas
             # names=range(max_node_no) to assure rectangular shape by cols
-            tmp = pd.read_csv(
-                msh,
-                engine="c",
+            filepos = msh.tell()
+            pd_kwargs = dict(
                 delim_whitespace=True,
                 nrows=no_elements,
                 names=range(max_node_no + 4),  # +4 for the "-1" entry
-            ).values
+            )
+            try:
+                tmp = pd.read_csv(msh, engine="c", **pd_kwargs).values
+            except pd.errors.ParserError:
+                msh.seek(filepos)
+                tmp = pd.read_csv(msh, engine="python", **pd_kwargs).values
             # check if all given element-typs are OGS known
             pos_ele = 2  # can be shift to right, if "-1" occures
             check_elem = np.in1d(tmp[:, pos_ele], ELEM_NAMES)


### PR DESCRIPTION
In some corner cases, reading a native OGS5 msh fails since the c-engine of pandas can't handle empty cols in some cases.
Using the python-engine as a fallback in this case can solve such problems.

Removed some old `from io import open` which were there for py2 compatibility.